### PR TITLE
Adding the no_search_result json message to all language files

### DIFF
--- a/public/language/ar/category.json
+++ b/public/language/ar/category.json
@@ -4,6 +4,7 @@
     "new_topic_button": "موضوع جديد",
     "guest-login-post": "سجل الدخول للمشاركة",
     "no_topics": "<strong>لا توجد مواضيع في هذه القسم</strong>لم لا تحاول إنشاء موضوع؟<br />",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "browsing": "تصفح",
     "no_replies": "لم يرد أحد",
     "no_new_posts": "لا توجد مشاركات جديدة.",

--- a/public/language/bg/category.json
+++ b/public/language/bg/category.json
@@ -7,6 +7,7 @@
     "browsing": "разглежда",
     "no_replies": "Няма отговори",
     "no_new_posts": "Няма нови публикации.",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "watch": "Следене",
     "ignore": "Пренебрегване",
     "watching": "Следите",

--- a/public/language/bn/category.json
+++ b/public/language/bn/category.json
@@ -5,6 +5,7 @@
     "guest-login-post": "উত্তর দিতে লগিন করুন",
     "no_topics": "<strong>এই বিভাগে কোন আলোচনা নেই! </strong><br /> আপনি চাইলে নতুন আলোচনা শুরু করতে পারেন।",
     "browsing": "ব্রাউজিং",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "no_replies": "কোন রিপ্লাই নেই",
     "no_new_posts": "নতুন কোন পোস্ট নাই",
     "watch": "নজর রাখুন",

--- a/public/language/cs/category.json
+++ b/public/language/cs/category.json
@@ -5,6 +5,7 @@
     "guest-login-post": "Přihlásit se pro přispívání",
     "no_topics": "<strong>V této kategorii zatím nejsou žádné příspěvky.</strong><br />Můžeš být první.",
     "browsing": "prohlíží",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "no_replies": "Nikdo ještě neodpověděl",
     "no_new_posts": "Žádné nové příspěvky",
     "watch": "Sledovat",

--- a/public/language/da/category.json
+++ b/public/language/da/category.json
@@ -5,6 +5,7 @@
     "guest-login-post": "Log ind",
     "no_topics": "<strong>Der er ikke nogen nye emner i denne kategori.</strong><br /> Hvorfor  prøver du ikke at lave et?",
     "browsing": "browse",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "no_replies": "Ingen har svaret",
     "no_new_posts": "Ingen nye indlæg",
     "watch": "Overvåg",

--- a/public/language/de/category.json
+++ b/public/language/de/category.json
@@ -5,6 +5,7 @@
     "guest-login-post": "Melde dich an, um einen Beitrag zu erstellen",
     "no_topics": "<strong>Es gibt noch keine Themen in dieser Kategorie.</strong><br />Warum beginnst du nicht eins?",
     "browsing": "Aktiv",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "no_replies": "Niemand hat geantwortet",
     "no_new_posts": "Keine neuen Beiträge.",
     "watch": "Beobachten",

--- a/public/language/el/category.json
+++ b/public/language/el/category.json
@@ -5,6 +5,7 @@
     "guest-login-post": "Συνδέσου για να δημοσιεύσεις",
     "no_topics": "<strong>Δεν υπάρχουν θέματα σε αυτή την κατηγορία.</strong><br />Γιατί δεν δοκιμάζεις να δημοσιεύσεις ένα εσύ;",
     "browsing": "περιηγούνται",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "no_replies": "Κανείς δεν έχει απαντήσει",
     "no_new_posts": "Δεν υπάρχουν νέες δημοσιεύσεις",
     "watch": "Παρακολουθήστε",

--- a/public/language/en-US/category.json
+++ b/public/language/en-US/category.json
@@ -7,6 +7,7 @@
     "browsing": "browsing",
     "no_replies": "No one has replied",
     "no_new_posts": "No new posts.",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "watch": "Watch",
     "ignore": "Ignore",
     "watching": "Watching",

--- a/public/language/en-x-pirate/category.json
+++ b/public/language/en-x-pirate/category.json
@@ -7,6 +7,7 @@
     "browsing": "browsin'",
     "no_replies": "No one has replied to ye message",
     "no_new_posts": "Thar be no new posts.",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "watch": "Be watchin'",
     "ignore": "Be ignorin'",
     "watching": "Watching",

--- a/public/language/es/category.json
+++ b/public/language/es/category.json
@@ -8,6 +8,7 @@
     "no_replies": "Nadie ha respondido aún",
     "no_new_posts": "No hay mensajes nuevos.",
     "watch": "Seguir",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "ignore": "Ignorar",
     "watching": "Siguiendo",
     "not-watching": "No siguiendo",

--- a/public/language/et/category.json
+++ b/public/language/et/category.json
@@ -8,6 +8,7 @@
     "no_replies": "Keegi pole vastanud",
     "no_new_posts": "Uusi postitusi pole",
     "watch": "Vaata",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "ignore": "Ignoreeri",
     "watching": "Vaatab",
     "not-watching": "Not Watching",

--- a/public/language/fa-IR/category.json
+++ b/public/language/fa-IR/category.json
@@ -8,6 +8,7 @@
     "no_replies": "هیچ کسی پاسخ نداده است.",
     "no_new_posts": "هیچ پست جدیدی وجود ندارد.",
     "watch": "پیگیری",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "ignore": "نادیده گرفتن",
     "watching": "درحال پیگیری",
     "not-watching": "درحال پیگیری نیستید",

--- a/public/language/fi/category.json
+++ b/public/language/fi/category.json
@@ -8,6 +8,7 @@
     "no_replies": "Kukaan ei ole vastannut",
     "no_new_posts": "Ei uusia viestejä",
     "watch": "Seuraa",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "ignore": "Sivuuta",
     "watching": "Seurataan",
     "not-watching": "Älä seuraa",

--- a/public/language/fr/category.json
+++ b/public/language/fr/category.json
@@ -8,6 +8,7 @@
     "no_replies": "Personne n'a répondu",
     "no_new_posts": "Pas de nouveau message",
     "watch": "S'abonner",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "ignore": "Ne plus surveiller",
     "watching": "Suivi",
     "not-watching": "Ne plus suivre",

--- a/public/language/gl/category.json
+++ b/public/language/gl/category.json
@@ -9,6 +9,7 @@
     "no_new_posts": "Non hai publicacións novas.",
     "watch": "Vixiar",
     "ignore": "Ignorar",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "watching": "Seguindo",
     "not-watching": "Not Watching",
     "ignoring": "Ignorando",

--- a/public/language/he/category.json
+++ b/public/language/he/category.json
@@ -9,6 +9,7 @@
     "no_new_posts": "אין פוסטים חדשים.",
     "watch": "עקוב",
     "ignore": "התעלם",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "watching": "עוקב",
     "not-watching": "לא עוקב",
     "ignoring": "מתעלם",

--- a/public/language/hr/category.json
+++ b/public/language/hr/category.json
@@ -9,6 +9,7 @@
     "no_new_posts": "Nema novih tema.",
     "watch": "Prati",
     "ignore": "Ignoriraj",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "watching": "Pratim",
     "not-watching": "Not Watching",
     "ignoring": "Ignoriram",

--- a/public/language/hu/category.json
+++ b/public/language/hu/category.json
@@ -9,6 +9,7 @@
     "no_new_posts": "Nincs új hozzászólás.",
     "watch": "Figyelés",
     "ignore": "Mellőzés",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "watching": "Figyelés",
     "not-watching": "Nem megfigyelt",
     "ignoring": "Mellőzés",

--- a/public/language/hy/category.json
+++ b/public/language/hy/category.json
@@ -10,6 +10,7 @@
     "watch": "Դիտել",
     "ignore": "Անտեսել",
     "watching": "Դիտում",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "not-watching": "Չեն դիտում ",
     "ignoring": "Անտեսել",
     "watching.description": "Ցույց տալ թեմաները չկարդացված և վերջին բաժնում ",

--- a/public/language/id/category.json
+++ b/public/language/id/category.json
@@ -10,6 +10,7 @@
     "watch": "mengamati",
     "ignore": "Abaikan",
     "watching": "mengamati",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "not-watching": "Not Watching",
     "ignoring": "Abaikan",
     "watching.description": "Show topics in unread and recent",

--- a/public/language/it/category.json
+++ b/public/language/it/category.json
@@ -10,6 +10,7 @@
     "watch": "Segui",
     "ignore": "Ignora",
     "watching": "Seguito",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "not-watching": "Non seguito",
     "ignoring": "Ignorato",
     "watching.description": "Mostra discussioni in non letti e recenti",

--- a/public/language/ja/category.json
+++ b/public/language/ja/category.json
@@ -11,6 +11,7 @@
     "ignore": "無視する",
     "watching": "ウォッチ中",
     "not-watching": "Not Watching",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "ignoring": "無視中",
     "watching.description": "Show topics in unread and recent",
     "not-watching.description": "Do not show topics in unread, show in recent",

--- a/public/language/ko/category.json
+++ b/public/language/ko/category.json
@@ -12,6 +12,7 @@
     "watching": "관심 카테고리",
     "not-watching": "관심 해제 카테고리",
     "ignoring": "카테고리 무시",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "watching.description": "읽지 않음과 최근 목록에 화제 표시",
     "not-watching.description": "읽지 않음 제외, 최근 목록에만 화제 표시",
     "ignoring.description": "읽지 않음과 최근 목록에서 화제 제외",

--- a/public/language/lt/category.json
+++ b/public/language/lt/category.json
@@ -12,6 +12,7 @@
     "watching": "Stebima",
     "not-watching": "Not Watching",
     "ignoring": "Ignoruojama",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "watching.description": "Show topics in unread and recent",
     "not-watching.description": "Do not show topics in unread, show in recent",
     "ignoring.description": "Do not show topics in unread and recent",

--- a/public/language/lv/category.json
+++ b/public/language/lv/category.json
@@ -9,6 +9,7 @@
     "no_new_posts": "Nav jaunu rakstu.",
     "watch": "Novērošana",
     "ignore": "Ignorēt",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "watching": "Novērots",
     "not-watching": "Not Watching",
     "ignoring": "Ignorēts",

--- a/public/language/ms/category.json
+++ b/public/language/ms/category.json
@@ -10,6 +10,7 @@
     "watch": "Melihat",
     "ignore": "Abai",
     "watching": "Watching",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "not-watching": "Not Watching",
     "ignoring": "Ignoring",
     "watching.description": "Show topics in unread and recent",

--- a/public/language/nb/category.json
+++ b/public/language/nb/category.json
@@ -10,6 +10,7 @@
     "watch": "Overvåk",
     "ignore": "Ignorer",
     "watching": "Følger",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "not-watching": "Følger ikke",
     "ignoring": "Ignorerer",
     "watching.description": "Vis tråder blandt uleste og nylige",

--- a/public/language/nl/category.json
+++ b/public/language/nl/category.json
@@ -10,6 +10,7 @@
     "watch": "Volgen",
     "ignore": "Negeren",
     "watching": "Volgend",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "not-watching": "Niet gevolgd",
     "ignoring": "Negerend",
     "watching.description": "Toon ongelezen en recente onderwerpen",

--- a/public/language/pl/category.json
+++ b/public/language/pl/category.json
@@ -10,6 +10,7 @@
     "watch": "Obserwuj",
     "ignore": "Ignoruj",
     "watching": "Obserwowane",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "not-watching": "Nie obserwowane",
     "ignoring": "Ignorowane",
     "watching.description": "Pokaż tematy w nieprzeczytanych i najnowszych",

--- a/public/language/pt-BR/category.json
+++ b/public/language/pt-BR/category.json
@@ -10,6 +10,7 @@
     "watch": "Acompanhar",
     "ignore": "Ignorar",
     "watching": "Acompanhar",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "not-watching": "Não Acompanhar",
     "ignoring": "Ignorar",
     "watching.description": "Mostrar tópicos em não-lidos e recentes",

--- a/public/language/pt-PT/category.json
+++ b/public/language/pt-PT/category.json
@@ -11,6 +11,7 @@
     "ignore": "Ignorar",
     "watching": "A seguir",
     "not-watching": "Não seguir",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "ignoring": "A ignorar",
     "watching.description": "Mostrar tópicos em \"não lidos\" e \"recentes\"",
     "not-watching.description": "Não mostrar tópicos em \"não lidos\", mostrar em \"recentes\"",

--- a/public/language/ro/category.json
+++ b/public/language/ro/category.json
@@ -11,6 +11,7 @@
     "ignore": "Ignoră",
     "watching": "Watching",
     "not-watching": "Not Watching",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "ignoring": "Ignoring",
     "watching.description": "Show topics in unread and recent",
     "not-watching.description": "Do not show topics in unread, show in recent",

--- a/public/language/ru/category.json
+++ b/public/language/ru/category.json
@@ -11,6 +11,7 @@
     "ignore": "Игнорировать",
     "watching": "Отслеживается",
     "not-watching": "Не отслеживается",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "ignoring": "Игнорируется",
     "watching.description": "Показывать темы из этой категории в списках непрочитанных и недавних",
     "not-watching.description": "Не показывать темы из этой категории в непрочитанных, но оставить в списке недавних",

--- a/public/language/rw/category.json
+++ b/public/language/rw/category.json
@@ -11,6 +11,7 @@
     "ignore": "Ihorere",
     "watching": "Watching",
     "not-watching": "Not Watching",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "ignoring": "Ignoring",
     "watching.description": "Show topics in unread and recent",
     "not-watching.description": "Do not show topics in unread, show in recent",

--- a/public/language/sc/category.json
+++ b/public/language/sc/category.json
@@ -11,6 +11,7 @@
     "ignore": "Ignore",
     "watching": "Watching",
     "not-watching": "Not Watching",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "ignoring": "Ignoring",
     "watching.description": "Show topics in unread and recent",
     "not-watching.description": "Do not show topics in unread, show in recent",

--- a/public/language/sk/category.json
+++ b/public/language/sk/category.json
@@ -11,6 +11,7 @@
     "ignore": "Ignorovať",
     "watching": "Sledované",
     "not-watching": "Not Watching",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "ignoring": "Ignorovať",
     "watching.description": "Show topics in unread and recent",
     "not-watching.description": "Do not show topics in unread, show in recent",

--- a/public/language/sl/category.json
+++ b/public/language/sl/category.json
@@ -11,6 +11,7 @@
     "ignore": "Prezri.",
     "watching": "Spremljano",
     "not-watching": "Ni spremljano",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "ignoring": "Prezrto",
     "watching.description": "Prikaži teme v nedavno in nazadnje",
     "not-watching.description": "Do not show topics in unread, show in recent",

--- a/public/language/sq-AL/category.json
+++ b/public/language/sq-AL/category.json
@@ -11,6 +11,7 @@
     "ignore": "Injoro",
     "watching": "Ndiq temën",
     "not-watching": "Mos e ndiq temën",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "ignoring": "Injoro",
     "watching.description": "Shfaq temat e fundit dhe të palexuara ",
     "not-watching.description": "Mos shfaq temat e palexuara, shfaq vetem temat më të fundit",

--- a/public/language/sr/category.json
+++ b/public/language/sr/category.json
@@ -11,6 +11,7 @@
     "ignore": "Игнориши",
     "watching": "Надгледај",
     "not-watching": "Не надгледај",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "ignoring": "Игнориши",
     "watching.description": "Прикажи теме у непрочитаним и недавним",
     "not-watching.description": "Не приказуј теме у непрочитаним, прикажи у недавним",

--- a/public/language/sv/category.json
+++ b/public/language/sv/category.json
@@ -11,6 +11,7 @@
     "ignore": "Ignorera",
     "watching": "Bevakar",
     "not-watching": "Följer inte",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "ignoring": "Ignorerar",
     "watching.description": "Visa ämnen i olästa och senaste",
     "not-watching.description": "Visa inte ämnen i olästa, visa i senaste",

--- a/public/language/th/category.json
+++ b/public/language/th/category.json
@@ -11,6 +11,7 @@
     "ignore": "ไม่ต้องสนใจอีก",
     "watching": "กำลังตามดู",
     "not-watching": "Not Watching",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "ignoring": "เมินเฉย",
     "watching.description": "Show topics in unread and recent",
     "not-watching.description": "Do not show topics in unread, show in recent",

--- a/public/language/tr/category.json
+++ b/public/language/tr/category.json
@@ -11,6 +11,7 @@
     "ignore": "Yok say",
     "watching": "Takip ediliyor",
     "not-watching": "Takip edilmiyor",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "ignoring": "Yok sayılıyor",
     "watching.description": "Bu kategorideki konuları, okunmamış ve güncel konular arasında göster",
     "not-watching.description": "Bu kategorideki konuları, okunmamış konular arasında gösterme; ama güncel konular arasında göster",

--- a/public/language/uk/category.json
+++ b/public/language/uk/category.json
@@ -11,6 +11,7 @@
     "ignore": "Ігнорувати",
     "watching": "Відстежується",
     "not-watching": "Не спостерігається",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "ignoring": "Ігнорувати",
     "watching.description": "Показати теми в непрочитаних та останніх",
     "not-watching.description": "Не показувати теми в непрочитаних, показувати в останніх",

--- a/public/language/vi/category.json
+++ b/public/language/vi/category.json
@@ -11,6 +11,7 @@
     "ignore": "Bỏ qua",
     "watching": "Đang xem",
     "not-watching": "Không xem",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "ignoring": "Bỏ qua",
     "watching.description": "Hiển thị chủ đề chưa đọc và gần đây",
     "not-watching.description": "Không hiển thị chủ đề trong chưa đọc, hiển thị gần đây",

--- a/public/language/zh-CN/category.json
+++ b/public/language/zh-CN/category.json
@@ -11,6 +11,7 @@
     "ignore": "忽略",
     "watching": "已关注",
     "not-watching": "未关注",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "ignoring": "已忽略",
     "watching.description": "显示未读和最近的主题",
     "not-watching.description": "不显示未读主题，显示最近主题",

--- a/public/language/zh-TW/category.json
+++ b/public/language/zh-TW/category.json
@@ -11,6 +11,7 @@
     "ignore": "忽略",
     "watching": "已關注",
     "not-watching": "未關注",
+    "no_search_result":"<strong>There are no topics under this search.</strong><br />Why don't you try posting one?",
     "ignoring": "已忽略",
     "watching.description": "顯示未讀和最近的主題",
     "not-watching.description": "不顯示未讀主題，顯示最近主題",


### PR DESCRIPTION
solves #21 We only put our JSON message under English and didn't realize it was causing an error because that same JSON message was not available under other languages. This PR simply adds the message to all language Categorys.JS JSON files in an attempt to get that fixed.