### PR TITLE
Endorse UI component

### DIFF
--- a/themes/nodebb-theme-persona/templates/partials/post_bar.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/post_bar.tpl
@@ -17,4 +17,5 @@
     <!-- IMPORT partials/thread_tools.tpl -->
     </div>
     <!-- IMPORT partials/topic/reply-button.tpl -->
+    <!-- IMPORT partials/topic/endorse-button.tpl -->
 </div>

--- a/themes/nodebb-theme-persona/templates/partials/topic/endorse-button.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/endorse-button.tpl
@@ -3,6 +3,12 @@
 </div>
 
 
+<style>
+#Notes topic/endorse or topic/endorse/container are used to get the route I believe.
+#Need to fix the privliges so only instructors can see it.
+
+
+</style>
 
 <!-- IF loggedIn -->
 <!-- IF !privileges.topics:reply -->

--- a/themes/nodebb-theme-persona/templates/partials/topic/endorse-button.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/endorse-button.tpl
@@ -1,0 +1,20 @@
+<div component="topic/endorse/container" class="btn-group action-bar bottom-sheet <!-- IF !privileges.topics:reply -->hidden<!-- ENDIF !privileges.topics:reply -->">
+    <button id = "endorse-button" class="btn btn-sm btn-primary" component="topic/endorse" type="submit" data-ajaxify="false" role="button"><i class="fa fa-reply visible-xs-inline"></i><span class="visible-sm-inline visible-md-inline visible-lg-inline"> [[topic:Endorse]]</span></button>
+</div>
+
+
+
+<!-- IF loggedIn -->
+<!-- IF !privileges.topics:reply -->
+<!-- IF locked -->
+<!-- ENDIF locked -->
+<!-- ENDIF !privileges.topics:reply -->
+
+<!-- IF !locked -->
+<!-- ENDIF !locked -->
+
+<!-- ELSE -->
+
+<!-- IF !privileges.topics:reply -->
+<!-- ENDIF !privileges.topics:reply -->
+<!-- ENDIF loggedIn -->


### PR DESCRIPTION
solves #22 

Created a new partial called endorse-button.tpl that creates a button. This is then inserted in post_bar.tpl next to the reply button which is inserted in topic.tpl. 

I tried to match the reply button as best as I could. This button will eventually be updated as it needs to have instructor-only privileges as well as needs some more style to have a different state when clicked. 

I am pushing this PR so my teammates can begin to connect this to the backend while I work on cosmetics and privileges. 