### PR TITLE
Added endorsed key value pair

### DIFF
--- a/src/posts/create.js
+++ b/src/posts/create.js
@@ -56,6 +56,7 @@ module.exports = function (Posts) {
 
         await Promise.all([
             db.sortedSetAdd('posts:pid', timestamp, postData.pid),
+            db.set(`posts:${postData.pid}:endorsed`, 'false'),
             db.incrObjectField('global', 'postCount'),
             user.onNewPostMade(postData),
             topics.onNewPostMade(postData),


### PR DESCRIPTION
Close #24 

Changes Made:
- Added the line `db.set(`posts:${postData.pid}:endorsed`, 'false')` to src/posts/create.js
- This creates the key value pair 'posts:pid:endorsed' : 'false' every time a new post is created

Testing:
- Tested manually with new post and saw the key-value pair in the redis database using redis-cli
- npm lint and npm tests pass