### PR TITLE
Implemented functions to get and set endorsed status on posts

### DIFF
--- a/src/posts/index.js
+++ b/src/posts/index.js
@@ -27,6 +27,25 @@ require('./queue')(Posts);
 require('./diffs')(Posts);
 require('./uploads')(Posts);
 
+/* Input : pid of the post to get endorsed status of
+ * Output : A string of whether the given pid's post is endorsed or not
+ *          'true' if it is, 'false' if not
+ */
+Posts.getEndorsed = async function (pid) {
+    console.assert(typeof pid, 'number');
+    return await db.get(`posts:${pid}:endorsed`);
+};
+
+/* Input : pid: the pid of the post to get endorsed status of
+ *         flag: a boolean representing whether to set the endorsed to true or false
+ */
+Posts.toggleSetEndorsed = async function (pid, flag) {
+    console.assert(typeof pid, 'number');
+    console.assert(typeof flag, 'boolean');
+    const value = flag ? 'true' : 'false';
+    await db.set(`posts:${pid}:endorsed`, value);
+};
+
 Posts.exists = async function (pids) {
     return await db.exists(
         Array.isArray(pids) ? pids.map(pid => `post:${pid}`) : `post:${pids}`

--- a/test/posts.js
+++ b/test/posts.js
@@ -302,6 +302,27 @@ describe('Post\'s', () => {
         });
     });
 
+    describe('endorsing', () => {
+        it('should endorse a post', async () => {
+            await posts.toggleSetEndorsed(postData.pid, true);
+            const endorsed = await posts.getEndorsed(postData.pid);
+            console.assert(typeof endorsed, 'string');
+            assert.equal(endorsed, 'true');
+        });
+
+        it('should unendorse a post', async () => {
+            await posts.toggleSetEndorsed(postData.pid, true);
+            const endorsed = await posts.getEndorsed(postData.pid);
+            console.assert(typeof endorsed, 'string');
+            assert.equal(endorsed, 'true');
+
+            await posts.toggleSetEndorsed(postData.pid, false);
+            const unendorsed = await posts.getEndorsed(postData.pid);
+            console.assert(typeof unendorsed, 'string');
+            assert.equal(unendorsed, 'false');
+        });
+    });
+
     describe('post tools', () => {
         it('should error if data is invalid', (done) => {
             socketPosts.loadPostTools({ uid: globalModUid }, null, (err) => {


### PR DESCRIPTION
This PR introduces new functions to manage the endorsement status of posts. It adds two primary functions to the `src/posts/index.js` file and corresponding test cases in the `test/posts.js` file. These functions allow us to retrieve (`getEndorsed `) and set (`toggleSetEndorsed `) the endorsement status of any given post. 

Changes Made:
src/posts.index.js:
Added a new function `Posts.getEndorsed(pid)` that retrieves the endorsement status of a post based on its unique post ID. The function returns a string with the value 'true' if the post is endorsed and 'false' if it is not.

Added a new function `Posts.toggleSetEndorsed(pid, flag)` to toggle and set the endorsement status of a post. This function takes two arguments: pid (post ID) and flag, a boolean indicating whether to set the endorsement status to true or false. The function updates the status in our database accordingly.

test/posts.js:
Added a test case to ensure that a post can be endorsed, and the Posts.getEndorsed function correctly returns 'true' when the post is endorsed. Another test case was added for unendorsing, where Posts.getEndorsed function returns 'false' when the post is unendorsed.

Closes #25 