### PR TITLE
Display endorsement message in the front end

### DIFF
--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -51,6 +51,12 @@
 
 <div class="content" component="post/content" itemprop="text">
     {posts.content}
+    <!-- IF posts.endorsed -->
+    <br>
+    <div style="color: green; text-align: center; font-weight: bold;">
+    ~An instructor has endorsed this post~
+    </div>
+    <!-- ENDIF posts.endorsed -->
 </div>
 
 <div class="post-footer">

--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -90,7 +90,11 @@
             <a component="post/quote" href="#" class="no-select <!-- IF !privileges.topics:reply -->hidden<!-- ENDIF !privileges.topics:reply -->">[[topic:quote]]</a>
             <form>
                  <button id = "endorse" type="submit" aria-label="Endorse">
-                    Endorse
+                    <!-- IF !posts.endorsed -->
+                        Endorse
+                    <!-- ELSE -->
+                        Unendorse
+                    <!-- END IF !posts.endorsed -->
                 </button>
                 <style>
                     #endorse{


### PR DESCRIPTION
closes #26 

This pull request is about displaying the correct endorsement status on the posts that have been endorsed by an instructor and changing the endorsement button's status once it has been endorsed to "Unendorse", in case the instructor needs to cancel their endorsement.

Changes made:
In order to display the endorsement message, I added a conditional statement in the themes/nodebb-theme-persona/templates/partials/topic/post.tpl file. If a post has been endorsed, the message `~An instructor has endorsed this post~` will be displayed under the content of the post that has been endorsed. 
In order to change the endorsement button to "Unendorse", I added the same conditional, and the button will toggle from "Endorse" to "Unendorse" based on the endorsement status sent from the database.

Testing:
First ran `npm run lint` and `npm run test` to make sure it passes the test suits. Then, I changed the conditional statement to `if posts.endorse == false` (this is because the value for endorsement is defaulted to false when a post is first created), then the endorsement message will be displayed in the front end, to make sure that the endorse value is being successfully passed on to render and can be displayed in the front end. Did the same to the button, and made sure the endorsement status was being checked for the text on the button.