### PR TITLE
Reva - experimenting with connecting frontend to backend 

### DIFF
--- a/public/src/client/topic/events.js
+++ b/public/src/client/topic/events.js
@@ -18,7 +18,7 @@ define('forum/topic/events', [
         'event:user_status_change': onUserStatusChange,
         'event:voted': updatePostVotesAndUserReputation,
         'event:bookmarked': updateBookmarkCount,
-        'event:endorsed': toggleSetEndorsed,
+        'event:endorsed': postTools.toggleSetEndorsed,
         'event:topic_deleted': threadTools.setDeleteState,
         'event:topic_restored': threadTools.setDeleteState,
         'event:topic_purged': onTopicPurged,

--- a/public/src/client/topic/events.js
+++ b/public/src/client/topic/events.js
@@ -18,7 +18,7 @@ define('forum/topic/events', [
         'event:user_status_change': onUserStatusChange,
         'event:voted': updatePostVotesAndUserReputation,
         'event:bookmarked': updateBookmarkCount,
-
+        'event:endorsed': toggleSetEndorsed,
         'event:topic_deleted': threadTools.setDeleteState,
         'event:topic_restored': threadTools.setDeleteState,
         'event:topic_purged': onTopicPurged,

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -116,6 +116,10 @@ define('forum/topic/postTools', [
             return bookmarkPost($(this), getData($(this), 'data-pid'));
         });
 
+        postContainer.on('click', '[component="post/endorse"]', function () {
+            onEndorseClicked($(this), getData($(this), 'data-pid'));
+        });
+
         postContainer.on('click', '[component="post/upvote"]', function () {
             return votes.toggleVote($(this), '.upvoted', 1);
         });

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -116,9 +116,9 @@ define('forum/topic/postTools', [
             return bookmarkPost($(this), getData($(this), 'data-pid'));
         });
 
-        postContainer.on('click', '[component="post/endorse"]', function () {
-            onEndorseClicked($(this), getData($(this), 'data-pid'));
-        });
+        // postContainer.on('click', '[component="post/endorse"]', function () {
+        //     posts.toggleSetEndorsedt($(this), getData($(this), 'data-pid'));
+        // });
 
         postContainer.on('click', '[component="post/upvote"]', function () {
             return votes.toggleVote($(this), '.upvoted', 1);

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -1,6 +1,8 @@
 'use strict';
 
 
+const posts = require('../../../../src/posts');
+
 define('forum/topic/postTools', [
     'share',
     'navigator',
@@ -116,9 +118,9 @@ define('forum/topic/postTools', [
             return bookmarkPost($(this), getData($(this), 'data-pid'));
         });
 
-        // postContainer.on('click', '[component="post/endorse"]', function () {
-        //     posts.toggleSetEndorsedt($(this), getData($(this), 'data-pid'));
-        // });
+        postContainer.on('click', '[component="post/endorse"]', function () {
+            posts.toggleSetEndorsed($(this), getData($(this), 'data-pid'));
+        });
 
         postContainer.on('click', '[component="post/upvote"]', function () {
             return votes.toggleVote($(this), '.upvoted', 1);

--- a/src/api/helpers.js
+++ b/src/api/helpers.js
@@ -117,6 +117,8 @@ exports.postCommand = async function (caller, command, eventName, notification, 
         filter:post.unvote
         filter:post.bookmark
         filter:post.unbookmark
+        filter:post.endorsed
+        filter:post.unendorsed
      */
     const filteredData = await plugins.hooks.fire(`filter:post.${command}`, {
         data: data,

--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -273,6 +273,14 @@ postsAPI.unbookmark = async function (caller, data) {
     return await apiHelpers.postCommand(caller, 'unbookmark', 'bookmarked', '', data);
 };
 
+postsAPI.endorse = async function (caller, data) {
+    return await apiHelpers.postCommand(caller, 'endorse', 'endorsed', '', data);
+};
+
+postsAPI.unendorse = async function (caller, data) {
+    return await apiHelpers.postCommand(caller, 'unendorse', 'endorsed', '', data);
+};
+
 async function diffsPrivilegeCheck(pid, uid) {
     const [deleted, privilegesData] = await Promise.all([
         posts.getPostField(pid, 'deleted'),

--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -273,13 +273,13 @@ postsAPI.unbookmark = async function (caller, data) {
     return await apiHelpers.postCommand(caller, 'unbookmark', 'bookmarked', '', data);
 };
 
-postsAPI.endorse = async function (caller, data) {
-    return await apiHelpers.postCommand(caller, 'endorse', 'endorsed', '', data);
-};
+// postsAPI.endorse = async function (caller, data) {
+//     return await apiHelpers.postCommand(caller, 'endorse', 'endorsed', '', data);
+// };
 
-postsAPI.unendorse = async function (caller, data) {
-    return await apiHelpers.postCommand(caller, 'unendorse', 'endorsed', '', data);
-};
+// postsAPI.unendorse = async function (caller, data) {
+//     return await apiHelpers.postCommand(caller, 'unendorse', 'endorsed', '', data);
+// };
 
 async function diffsPrivilegeCheck(pid, uid) {
     const [deleted, privilegesData] = await Promise.all([

--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -273,13 +273,13 @@ postsAPI.unbookmark = async function (caller, data) {
     return await apiHelpers.postCommand(caller, 'unbookmark', 'bookmarked', '', data);
 };
 
-// postsAPI.endorse = async function (caller, data) {
-//     return await apiHelpers.postCommand(caller, 'endorse', 'endorsed', '', data);
-// };
+postsAPI.endorse = async function (caller, data) {
+    return await apiHelpers.postCommand(caller, 'endorse', 'endorsed', '', data);
+};
 
-// postsAPI.unendorse = async function (caller, data) {
-//     return await apiHelpers.postCommand(caller, 'unendorse', 'endorsed', '', data);
-// };
+postsAPI.unendorse = async function (caller, data) {
+    return await apiHelpers.postCommand(caller, 'unendorse', 'endorsed', '', data);
+};
 
 async function diffsPrivilegeCheck(pid, uid) {
     const [deleted, privilegesData] = await Promise.all([

--- a/src/controllers/posts.js
+++ b/src/controllers/posts.js
@@ -27,10 +27,6 @@ postsController.redirectToPost = async function (req, res, next) {
 
     const qs = querystring.stringify(req.query);
     helpers.redirect(res, qs ? `${path}?${qs}` : path);
-
-    if (data.query.endorse_button) {
-
-    }
 };
 
 postsController.getRecentPosts = async function (req, res) {

--- a/src/controllers/posts.js
+++ b/src/controllers/posts.js
@@ -27,6 +27,10 @@ postsController.redirectToPost = async function (req, res, next) {
 
     const qs = querystring.stringify(req.query);
     helpers.redirect(res, qs ? `${path}?${qs}` : path);
+
+    if (data.query.endorse_button) {
+
+    }
 };
 
 postsController.getRecentPosts = async function (req, res) {

--- a/src/controllers/write/posts.js
+++ b/src/controllers/write/posts.js
@@ -85,6 +85,18 @@ Posts.unbookmark = async (req, res) => {
     helpers.formatApiResponse(200, res);
 };
 
+Posts.endorse = async (req, res) => {
+    const data = await mock(req);
+    await api.posts.endorse(req, data);
+    helpers.formatApiResponse(200, res);
+};
+
+Posts.unendorse = async (req, res) => {
+    const data = await mock(req);
+    await api.posts.endorse(req, data);
+    helpers.formatApiResponse(200, res);
+};
+
 Posts.getDiffs = async (req, res) => {
     helpers.formatApiResponse(200, res, await api.posts.getDiffs(req, { ...req.params }));
 };

--- a/src/controllers/write/posts.js
+++ b/src/controllers/write/posts.js
@@ -65,6 +65,8 @@ Posts.vote = async (req, res) => {
     helpers.formatApiResponse(200, res);
 };
 
+
+
 Posts.unvote = async (req, res) => {
     const data = await mock(req);
     await api.posts.unvote(req, data);

--- a/src/controllers/write/posts.js
+++ b/src/controllers/write/posts.js
@@ -87,18 +87,6 @@ Posts.getDiffs = async (req, res) => {
     helpers.formatApiResponse(200, res, await api.posts.getDiffs(req, { ...req.params }));
 };
 
-Posts.endorse = async (req, res) => {
-    const data = await mock(req);
-    await api.posts.endorse(req, data);
-    helpers.formatApiResponse(200, res);
-};
-
-Posts.unendorse = async (req, res) => {
-    const data = await mock(req);
-    await api.posts.unendorse(req, data);
-    helpers.formatApiResponse(200, res);
-};
-
 Posts.loadDiff = async (req, res) => {
     helpers.formatApiResponse(200, res, await api.posts.loadDiff(req, { ...req.params }));
 };

--- a/src/controllers/write/posts.js
+++ b/src/controllers/write/posts.js
@@ -87,6 +87,18 @@ Posts.getDiffs = async (req, res) => {
     helpers.formatApiResponse(200, res, await api.posts.getDiffs(req, { ...req.params }));
 };
 
+Posts.endorse = async (req, res) => {
+    const data = await mock(req);
+    await api.posts.endorse(req, data);
+    helpers.formatApiResponse(200, res);
+};
+
+Posts.unendorse = async (req, res) => {
+    const data = await mock(req);
+    await api.posts.unendorse(req, data);
+    helpers.formatApiResponse(200, res);
+};
+
 Posts.loadDiff = async (req, res) => {
     helpers.formatApiResponse(200, res, await api.posts.loadDiff(req, { ...req.params }));
 };

--- a/src/posts/index.js
+++ b/src/posts/index.js
@@ -46,6 +46,18 @@ Posts.toggleSetEndorsed = async function (pid, flag) {
     await db.set(`posts:${pid}:endorsed`, value);
 };
 
+Posts.endorsed = async function (pid, uid) {
+    console.assert(typeof pid, 'number');
+    console.assert(typeof uid, 'number');
+    await db.set(`posts:${pid}:endorsed`, true);
+};
+
+Posts.unendorsed = async function (pid, uid) {
+    console.assert(typeof pid, 'number');
+    console.assert(typeof uid, 'number');
+    await db.set(`posts:${pid}:endorsed`, false);
+};
+
 Posts.exists = async function (pids) {
     return await db.exists(
         Array.isArray(pids) ? pids.map(pid => `post:${pid}`) : `post:${pids}`

--- a/src/routes/write/posts.js
+++ b/src/routes/write/posts.js
@@ -31,5 +31,7 @@ module.exports = function () {
     setupApiRoute(router, 'put', '/:pid/diffs/:since', [...middlewares, middleware.assert.post], controllers.write.posts.restoreDiff);
     setupApiRoute(router, 'delete', '/:pid/diffs/:timestamp', [...middlewares, middleware.assert.post], controllers.write.posts.deleteDiff);
 
+    setupApiRoute(router, 'put', '/:pid/endorse', [...middlewares, middleware.assert.post], controllers.write.posts.endorse);
+    setupApiRoute(router, 'delete', '/:pid/endorse', [...middlewares, middleware.assert.post], controllers.write.posts.unendorse);
     return router;
 };

--- a/src/routes/write/posts.js
+++ b/src/routes/write/posts.js
@@ -31,7 +31,9 @@ module.exports = function () {
     setupApiRoute(router, 'put', '/:pid/diffs/:since', [...middlewares, middleware.assert.post], controllers.write.posts.restoreDiff);
     setupApiRoute(router, 'delete', '/:pid/diffs/:timestamp', [...middlewares, middleware.assert.post], controllers.write.posts.deleteDiff);
 
-    setupApiRoute(router, 'put', '/:pid/endorse', [...middlewares, middleware.assert.post], controllers.write.posts.endorse);
-    setupApiRoute(router, 'delete', '/:pid/endorse', [...middlewares, middleware.assert.post], controllers.write.posts.unendorse);
+    // setupApiRoute(router, 'put', '/:pid/endorse', [...middlewares, middleware.assert.post],
+    // controllers.write.posts.endorse);
+    // setupApiRoute(router, 'delete', '/:pid/endorse', [...middlewares, middleware.assert.post],
+    // controllers.write.posts.unendorse);
     return router;
 };

--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -82,7 +82,7 @@
         <span class="post-tools" style="display: flex; justify-content: space-between; align-items: center;">
             <a component="post/reply" href="#" class="no-select <!-- IF !privileges.topics:reply -->hidden<!-- ENDIF !privileges.topics:reply -->">[[topic:reply]]</a>
             <a component="post/quote" href="#" class="no-select <!-- IF !privileges.topics:reply -->hidden<!-- ENDIF !privileges.topics:reply -->">[[topic:quote]]</a>
-            <form>
+            <form id = "endorse_button" action = {config.relative_path}/category>
                  <button id = "endorse" type="submit" aria-label="Endorse">
                     Endorse
                 </button>

--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -82,8 +82,8 @@
         <span class="post-tools" style="display: flex; justify-content: space-between; align-items: center;">
             <a component="post/reply" href="#" class="no-select <!-- IF !privileges.topics:reply -->hidden<!-- ENDIF !privileges.topics:reply -->">[[topic:reply]]</a>
             <a component="post/quote" href="#" class="no-select <!-- IF !privileges.topics:reply -->hidden<!-- ENDIF !privileges.topics:reply -->">[[topic:quote]]</a>
-            <form id = "endorse_button" action = {config.relative_path}/category>
-                 <button id = "endorse" type="submit" aria-label="Endorse">
+            <form" >
+                 <button id = "endorse" type="submit" aria-label="Endorse", onclick="toggleSetEndorsed()">
                     Endorse
                 </button>
                 <style>


### PR DESCRIPTION
This PR experiments with connecting the endorse button in the front end to the backend, where functions regarding the endorse feature of the post are implemented. I was unable to fully implement it, however did make some changes throughout the process. 

Tried the following changes: 
Edited themes/nodebb-theme-persona/templates/partials/topic/post.tpl in order to include and inline event handler that specifies what happens when the button is clicked. It tried to calls the following function: toggleSetEndorsed()
Also tried to set up API routes, to essentially set up a PUT route for endorsing a post. setupApiRoute configures the route from the button to the backend where it can then retrieve info to endorse and unendorse posts, in src/routes/write/posts.js

Next Steps: 
These approaches all experimenting with setting up APIroutes to try and connecting the frontend to the backend, however I am not fully sure how to implement a concrete route. 
Need guidance on a concrete connection between the button input and the back end functions to successfully store the endorsed value for the post. 