### PR TITLE
Added standardJS static tool 

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -15,6 +15,7 @@ logs/
 *.iws
 /coverage
 /build
+.standard
 .eslintrc
 test/files
 *.min.js


### PR DESCRIPTION
This pull request introduces the StandardJS static tool to NodeBB, which provides code styling and formatting errors. No configuration required to the codebase. 

Screenshot of Terminal after executing the test ("npx standard"): 
<img width="1360" alt="Screenshot 2023-10-27 at 11 48 18 AM" src="https://github.com/CMU-313/fall23-nodebb-appa-momo-gang/assets/95151261/16f21ce9-925c-4e6a-bd45-f5e0efce9d69">

